### PR TITLE
Specify foundation-rails version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,5 +63,5 @@ end
 
 gem "slim-rails"
 gem "pub_med_apps", git: "https://github.com/SuperLavaSquadron/PubMedApps.git"
-gem "foundation-rails"
+gem "foundation-rails", "5.5.1.0"
 gem "responders"


### PR DESCRIPTION
Specifying a particular version of foundation that works.

`5.5.1.0` works, the new version does not.
